### PR TITLE
Just fixing a minor output issue

### DIFF
--- a/LateboundConstantGenerator/LateboundConstantGenerator.csproj.user
+++ b/LateboundConstantGenerator/LateboundConstantGenerator.csproj.user
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>C:\Users\hughesd\Source\Repos\LateboundConstantsGenerator\LateboundConstantGenerator\bin\Debug\XrmToolBox.exe</StartProgram>
+    <StartArguments>/overridepath:.</StartArguments>
+  </PropertyGroup>
+</Project>

--- a/LateboundConstantGenerator/MetadataProxy.cs
+++ b/LateboundConstantGenerator/MetadataProxy.cs
@@ -48,7 +48,9 @@ namespace Rappen.XTB.LCG
                 .Replace("-", "_")
                 .Replace("+", "_")
                 .Replace("/", "_")
-                .Replace("\\", "_");
+                .Replace("\\", "_")
+                .Replace("[", "_")
+                .Replace("]", "_"); 
         }
     }
 }

--- a/LateboundConstantGenerator/MetadataProxy.cs
+++ b/LateboundConstantGenerator/MetadataProxy.cs
@@ -50,7 +50,7 @@ namespace Rappen.XTB.LCG
                 .Replace("/", "_")
                 .Replace("\\", "_")
                 .Replace("[", "_")
-                .Replace("]", "_"); 
+                .Replace("]", "_");
         }
     }
 }


### PR DESCRIPTION
When CRM has "[" or "]" in an enum text, the generated class is invalid.
Have added them to the global replace list